### PR TITLE
Prevent spot title overflow

### DIFF
--- a/members/templates/members/snippets/trainingszeiten.html
+++ b/members/templates/members/snippets/trainingszeiten.html
@@ -80,7 +80,7 @@
                             {%endif%}
                             {% if session.agegroup in request.user.profile.agegroups.all or request.user.profile.privileged %}
                             <div style="display: flex; justify-content: space-between; gap:5px;">
-                                <h4> {{session.spot.title}}</h4>
+                                <h4 style="text-overflow: ellipsis; overflow: hidden;" title="{{session.spot.title}}">{{session.spot.title}}</h4>
                                 <a class="more_info_button" style="padding:0px" target="_blank"
                                     href="https://www.google.de/maps/dir//{{session.spot.lat}},{{session.spot.long}}/@{{session.spot.lat}},{{session.spot.long}},17z">
                                     <i style="font-size:0.8rem;" class="fas fa-map-marker-alt more_info_button"></i>


### PR DESCRIPTION
In the training schedule grid, long spot titles (e.g. Wintergartenhochaus) push the map link out of the box.
Title length is now limited and also shown on mouseover, so that it's at least readable when too long.

Before:
<img width="224" alt="Bildschirmfoto 2023-12-15 um 17 09 25" src="https://github.com/twiox/web/assets/530742/1d40a53c-4028-47c7-bd95-b2c5e91cc00d">

After:
![Bildschirmfoto 2023-12-16 um 09 45 16](https://github.com/twiox/web/assets/530742/7fa6cece-8910-4b47-81ad-dd9d822e2875)
