### PR TITLE
Add timeout before executing migrations

### DIFF
--- a/docker-config/start-server.sh
+++ b/docker-config/start-server.sh
@@ -5,6 +5,7 @@ if [ ! -e $CONTAINER_ALREADY_STARTED ]; then
     touch $CONTAINER_ALREADY_STARTED
     echo "-- First container startup --"
     # YOUR_JUST_ONCE_LOGIC_HERE
+    sleep 2
     uv run manage.py migrate
     # copy static files created during build process to volume, so NGINX can reach it.
     cp -r /opt/twio_web/static /opt/.
@@ -12,5 +13,4 @@ else
     echo "-- Not first container startup --"
 fi
 
-uv run manage.py migrate
 gunicorn twio_web.wsgi:application --bind 0.0.0.0:8000


### PR DESCRIPTION
Automatic execution of deployments fails in docker-compoose setup. Probably because all services are restarted and MySQL is not ready yet. To "fix" this, a pause was added on startup.